### PR TITLE
[v1.0][NCLSUP-676] Remove sort by _uid because of memory

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/source/ElasticSearch.java
+++ b/src/main/java/org/jboss/pnc/bifrost/source/ElasticSearch.java
@@ -110,8 +110,7 @@ public class ElasticSearch {
                 .size(fetchSize + 1)
                 .from(0)
                 .sort(new FieldSortBuilder("@timestamp").order(getSortOrder(direction)))
-                .sort(new FieldSortBuilder("sequence").order(getSortOrder(direction)))
-                .sort(new FieldSortBuilder("_uid").order(getSortOrder(direction)));
+                .sort(new FieldSortBuilder("sequence").order(getSortOrder(direction)));
         if (searchAfter.isPresent()) {
             String timestamp = searchAfter.get().getTimestamp();
             TemporalAccessor accessor = DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(timestamp);


### PR DESCRIPTION
The _uid sort order consumes too much memory on the Elasticsearch part
and the latter then refuses to run any queries.

We could workaround it by cleaning up our old logs, but another
workaround is to just remove the _uid sort, at the risk of some logs
being slightly out of order.