### PR TITLE
Downgrade Quarkus to 2.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.11.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
     <quarkus.package.type>uber-jar</quarkus.package.type>
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,6 +76,8 @@ bifrost:
         sql: true
         bind-parameters: true
       statistics: true
+    devservices:
+      enabled: false
   bifrost:
     sourceClass: org.jboss.pnc.bifrost.source.db.DatabaseSource
   kafka2db:
@@ -91,3 +93,4 @@ bifrost:
     log:
       console:
         json: false
+


### PR DESCRIPTION
This is the last version that uploads uber jars to Maven Central. The issue with the latest Quarkus version will be fixed in a future release.