### PR TITLE
[NCL-8159] Clear the cache via other means

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/source/db/DatabaseSource.java
+++ b/src/main/java/org/jboss/pnc/bifrost/source/db/DatabaseSource.java
@@ -127,6 +127,8 @@ public class DatabaseSource implements Source {
         while (rowsIterator.hasNext() && rowNum < fetchSize) {
             rowNum++;
             LogLine row = rowsIterator.next();
+            // try again to get the entity manager to clear the first-level cache
+            LogLine.getEntityManager().detach(row);
             boolean last = !rowsIterator.hasNext();
             Line line = getLine(row, last);
             onLine.accept(line);
@@ -139,6 +141,8 @@ public class DatabaseSource implements Source {
 
         // [NCL-8159] clear session cache!
         Panache.getEntityManager().clear();
+        // why do both? first one didn't do anything
+        LogLine.getEntityManager().clear();
     }
 
     private void sanitizeFilters(Map<String, List<String>> matchFilters, Map<String, List<String>> prefixFilters) {


### PR DESCRIPTION
Trying to clear the Hibernate cache using
`Panache.getEntityManager().clear()` didn't work. So trying other ways to clear it.