### PR TITLE
[NCL-8159] Fix memory leak for metadata endpoint

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/source/db/DatabaseSource.java
+++ b/src/main/java/org/jboss/pnc/bifrost/source/db/DatabaseSource.java
@@ -126,6 +126,9 @@ public class DatabaseSource implements Source {
         while (rowsIterator.hasNext() && rowNum < fetchSize) {
             rowNum++;
             LogLine row = rowsIterator.next();
+            // [NCL-8159] try again to get the entity manager to clear the first-level cache, otherwise it can get
+            // really big
+            LogLine.getEntityManager().detach(row);
             boolean last = !rowsIterator.hasNext();
             Line line = getLine(row, last);
             onLine.accept(line);

--- a/src/main/java/org/jboss/pnc/bifrost/source/db/LogLine.java
+++ b/src/main/java/org/jboss/pnc/bifrost/source/db/LogLine.java
@@ -51,7 +51,6 @@ import javax.persistence.Table;
                 @Index(name = "idx_logline_loggerName", columnList = "loggerName"),
                 @Index(name = "idx_logline_fkey_logentry_id", columnList = "logentry_id") })
 @JsonDeserialize(using = LogLineDeserializer.class)
-@Cacheable
 public class LogLine extends PanacheEntityBase {
 
     @Id


### PR DESCRIPTION
We load all the log lines for a build in the metadata endpoint. By doing so, we cause the entity manager to have a reference to all the LogLine objects loaded in its first level cache. Unfortunately those LogLine objects are big and as we load more of them, this causes an OutOfMemoryError.

This commit tries to fix the memory leak by:
- Detaching the LogLine object from its entity manager to remove it from the first level cache and allowing the garbage collector to clean up after we have processed the LogLine
- removing the @Cacheable annotation for LogLine since we don't know the cache eviction policy