### PR TITLE
[NCL-8159] Batch Kafka support

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,6 +76,20 @@ bifrost:
   defaultSourceFetchSize: 100
   sourcePollThreads: 4
 '%test':
+  mp:
+    messaging:
+      incoming:
+        logs:
+          connector: smallrye-kafka
+          topic: logs-test
+          auto:
+            offset:
+              reset: earliest
+      outgoing:
+        logs-in:
+          connector: smallrye-kafka
+          topic: logs-test
+          merge: true
   quarkus:
     log:
       min-level: TRACE
@@ -93,7 +107,7 @@ bifrost:
         bind-parameters: true
       statistics: true
     devservices:
-      enabled: false
+      enabled: true
   bifrost:
     sourceClass: org.jboss.pnc.bifrost.source.db.DatabaseSource
   kafka2db:

--- a/src/test/java/org/jboss/pnc/bifrost/kafkaconsumer/Log2dbTest.java
+++ b/src/test/java/org/jboss/pnc/bifrost/kafkaconsumer/Log2dbTest.java
@@ -59,7 +59,7 @@ public class Log2dbTest {
     ObjectMapper mapper;
 
     @Inject
-    @Channel("logs")
+    @Channel("logs-in")
     Emitter<String> emitter;
 
     @Inject
@@ -83,6 +83,10 @@ public class Log2dbTest {
         emitMessages(10, "org.apache"); // excluded by config
         emitMessages(10, "org.jboss.pnc");
         semaphore.acquire();
+
+        // give some time for the commit to finish
+        Thread.sleep(1000);
+
         List<LogLine> stored = LogLine.listAll();
         Assertions.assertEquals(10, stored.size());
         stored.forEach(r -> {


### PR DESCRIPTION
This commit adds support to batch consume messages.

If any message in the batch causes an exception to be thrown because of some database or something uncaught, the:

- batch consumption is nacked and the whole batch is retried later
- any existing write to the db in the transaction is dropped (hence dropping any inserts from the batch)

This avoids any issue with writing the same lines several times in the db.