### PR TITLE
Fix LogEntryDbRepository::get method

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/source/db/LogEntryDbRepository.java
+++ b/src/main/java/org/jboss/pnc/bifrost/source/db/LogEntryDbRepository.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.bifrost.source.db;
 import io.quarkus.arc.Priority;
 
 import org.jboss.pnc.common.Strings;
+import org.jboss.pnc.common.concurrent.Sequence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +51,8 @@ public class LogEntryDbRepository implements LogEntryRepository {
         }
         return LogEntry.findExisting(logEntry).orElseGet(() -> {
             LOG.debug("Persisting LogEntry: " + logEntry);
+            // set a proper id since it's probably not set when we are trying to search for an existing log entry
+            logEntry.id = Sequence.nextId();
             logEntry.persist();
             return logEntry;
         });

--- a/src/test/java/org/jboss/pnc/bifrost/source/db/LogEntryDbRepositoryTest.java
+++ b/src/test/java/org/jboss/pnc/bifrost/source/db/LogEntryDbRepositoryTest.java
@@ -1,0 +1,45 @@
+package org.jboss.pnc.bifrost.source.db;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.jboss.pnc.common.Random;
+import org.jboss.pnc.common.concurrent.Sequence;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class LogEntryDbRepositoryTest {
+
+    @Inject
+    LogEntryDbRepository logEntryDbRepository;
+
+    @Test
+    @Transactional
+    void get() {
+
+        // First: let's explicitly create a logentry with id 0
+        long processContext = Random.randInt(0, 10000);
+        String processContextVariant = "0";
+        LogEntry logEntry = new LogEntry();
+        logEntry.id = 0L;
+        logEntry.setProcessContext(processContext);
+        logEntry.setProcessContextVariant(processContextVariant);
+        logEntry.setTemporary(false);
+        logEntry.persist();
+
+        // Second, let's create a second, unrelated logentry where the id is not set
+        long processContextSecond = Random.randInt(0, 10000);
+        LogEntry logEntryToSearch = new LogEntry();
+        logEntryToSearch.setProcessContext(processContextSecond);
+        logEntryToSearch.setProcessContextVariant(processContextVariant);
+        logEntryToSearch.setTemporary(false);
+
+        // search or insert it. Hopefully not Exception is thrown because the id of the second log is not set
+        LogEntry found = logEntryDbRepository.get(logEntryToSearch);
+        Assertions.assertEquals(processContextSecond, found.getProcessContext());
+    }
+}

--- a/src/test/java/org/jboss/pnc/bifrost/source/db/LogEntryTest.java
+++ b/src/test/java/org/jboss/pnc/bifrost/source/db/LogEntryTest.java
@@ -1,0 +1,31 @@
+package org.jboss.pnc.bifrost.source.db;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.jboss.pnc.common.Random;
+import org.jboss.pnc.common.concurrent.Sequence;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.transaction.Transactional;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class LogEntryTest {
+
+    @Test
+    @Transactional
+    void findExisting() {
+        long processContext = Random.randInt(0, 10000);
+        String processContextVariant = "0";
+        LogEntry logEntry = new LogEntry(Sequence.nextId(), processContext, processContextVariant, null, false, null);
+        logEntry.persist();
+
+        LogEntry toFind = new LogEntry(0L, processContext, processContextVariant, null, false, null);
+
+        Optional<LogEntry> existing = LogEntry.findExisting(toFind);
+        Assertions.assertTrue(existing.isPresent());
+    }
+}


### PR DESCRIPTION
The LogEntryDbRepository::get method is used to:
1. check if there is an existing logentry matching the process context, process context variant, and other values other than id
2. if there's a match, return that match
3. if there isn't, store that logentry

Step 3 fails consistenly in Bifrost with this error:
```
[2024-03-15T20:19:27.837Z] DEBUG [org.jboss.pnc.bifrost.source.db.LogEntryDbRepository] Persisting LogEntry: LogEntry(id=0, processContext=556571267898798080, processContextVariant=0, requestContext=, temporary=false, buildId=null)
[2024-03-15T20:19:27.839Z] ERROR [org.hibernate.engine.jdbc.batch.internal.BatchingBatch] HHH000315: Exception executing batch [java.sql.BatchUpdateException: Batch entry 0 insert into LogEntry (buildId, processContext, processContextVariant, requestContext, temporary, id) values (NULL, 556571267898798080, '0', '', 'FALSE', 0) was aborted: ERROR: duplicate key value violates unique constraint "logentry_pkey"
  Detail: Key (id)=(0) already exists.  Call getNextException to see other errors in the batch.], SQL: insert into LogEntry (buildId, processContext, processContextVariant, requestContext, temporary, id) values (?, ?, ?, ?, ?, ?)
[2024-03-15T20:19:27.839Z] WARN [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] SQL Error: 0, SQLState: 23505
[2024-03-15T20:19:27.839Z] ERROR [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] Batch entry 0 insert into LogEntry (buildId, processContext, processContextVariant, requestContext, temporary, id) values (NULL, 556571267898798080, '0', '', 'FALSE', 0) was aborted: ERROR: duplicate key value violates unique constraint "logentry_pkey"
  Detail: Key (id)=(0) already exists.  Call getNextException to see other errors in the batch.
[2024-03-15T20:19:27.839Z] ERROR [org.hibernate.engine.jdbc.spi.SqlExceptionHelper] ERROR: duplicate key value violates unique constraint "logentry_pkey"
  Detail: Key (id)=(0) already exists.
```

This is because we tend to use that method by building a `LogEntry` object with no id set. Since we didn't configure `LogEntry` to set an id if nothing is set, the default of the id is 0, and the insertion in step 3 will fail with duplicate key.

This commit fixes it by:
- setting a unique id on step 3.

Tests are written to make sure that error doesn't happen again.