### PR TITLE
Enable compression for resteasy classic

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/endpoint/RestImpl.java
+++ b/src/main/java/org/jboss/pnc/bifrost/endpoint/RestImpl.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.extension.annotations.WithSpan;
 
 import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.vertx.http.Compressed;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import org.jboss.pnc.api.bifrost.dto.Line;
@@ -40,6 +41,7 @@ import org.jboss.pnc.bifrost.endpoint.provider.DataProvider;
 import org.jboss.pnc.bifrost.source.db.FinalLog;
 import org.jboss.pnc.common.pnc.LongBase32IdConverter;
 import org.jboss.pnc.common.security.Md5;
+import org.jboss.resteasy.annotations.GZIP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -359,6 +361,13 @@ public class RestImpl implements Bifrost {
     @Produces(MediaType.TEXT_PLAIN)
     @GET
     @Path("/final-log/{buildId}/{tag}")
+    @GZIP
+    /**
+     * Get the final log of the build + tag
+     *
+     * Note: @GZIP annotation needed for resteasy classic. remove it when we switch to resteasy reactive
+     * https://quarkus.io/version/2.16/guides/resteasy#gzip-support
+     */
     public Response getFinalLog(@PathParam("buildId") String buildId, @PathParam("tag") String tag) {
 
         return Response.ok().entity((StreamingOutput) output -> {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,10 +45,17 @@ quarkus:
   http:
     host: localhost
     port: 8081
-    # gzip replies
+    # gzip replies (only active for resteasy reactive)
     enable-compression: true
-    # accept gzipped uploaded data to Quarkus
+    # accept gzipped uploaded data to Quarkus (only active for resteasy reactive)
     enable-decompression: true
+  resteasy:
+    # gzip replies (only active for resteasy classic)
+    # https://quarkus.io/version/2.16/guides/resteasy#gzip-support
+    gzip:
+      enabled: true
+      max-input: 200M
+
   datasource:
     db-kind: ${QUARKUS_DATASOURCE:postgresql}
     jdbc.url: ${QUARKUS_DATASOURCE_URL:}


### PR DESCRIPTION
From: https://quarkus.io/version/2.16/guides/resteasy#gzip-support