### PR TITLE
Refresh finallog before setting size

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/endpoint/LogUpload.java
+++ b/src/main/java/org/jboss/pnc/bifrost/endpoint/LogUpload.java
@@ -86,7 +86,10 @@ public class LogUpload {
         } catch (ValidationException ex) {
             throw new BadRequestException("The uploaded log has wrong checksums: " + ex.getMessage(), ex);
         }
+
+        FinalLog.getEntityManager().refresh(finalLog);
         finalLog.size = stream.readSize();
+
         return "ok";
     }
 


### PR DESCRIPTION
Apparently Hibernate isn't too happy if we modify an existing object that uses Blob within the same transaction. We get this error:

```
Caused by: java.sql.SQLException: could not reset reader
	at org.hibernate.engine.jdbc.BlobProxy.resetIfNeeded(BlobProxy.java:74)
	at org.hibernate.engine.jdbc.BlobProxy.getUnderlyingStream(BlobProxy.java:63)
	at org.hibernate.engine.jdbc.BlobProxy.getStream(BlobProxy.java:59)
```

The fix is to refresh the finallog object, and then we can modify it again.