### PR TITLE
Fix bug in Lifecycle::podOrdinalNumber

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/Lifecycle.java
+++ b/src/main/java/org/jboss/pnc/bifrost/Lifecycle.java
@@ -65,6 +65,6 @@ public class Lifecycle {
      * Extract pod ordinal number managed by StatefulSet out of hostname.
      */
     public static int podOrdinalNumber(String hostname) {
-        return Integer.parseInt(hostname.substring(hostname.lastIndexOf("-")));
+        return Integer.parseInt(hostname.substring(hostname.lastIndexOf("-") + 1));
     }
 }

--- a/src/test/java/org/jboss/pnc/bifrost/LifecycleTest.java
+++ b/src/test/java/org/jboss/pnc/bifrost/LifecycleTest.java
@@ -1,0 +1,18 @@
+package org.jboss.pnc.bifrost;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LifecycleTest {
+
+    @Test
+    void podOrdinalNumber() {
+        assertEquals(0, Lifecycle.podOrdinalNumber("liverpool-0"));
+        assertEquals(0, Lifecycle.podOrdinalNumber("liverpool-00"));
+        assertEquals(5, Lifecycle.podOrdinalNumber("liverpool-05"));
+        assertEquals(57, Lifecycle.podOrdinalNumber("liverpool-57"));
+        assertEquals(10, Lifecycle.podOrdinalNumber("liverpool-10"));
+        assertEquals(315, Lifecycle.podOrdinalNumber("liverpool-315"));
+    }
+}


### PR DESCRIPTION
The substring we grab was off by 1, so the numbers we used were negative. In the default case of running 1 pod, the negative number was -0, so it was never detected before.