### PR TITLE
Use sequence for the id of FinalLog

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/endpoint/LogUpload.java
+++ b/src/main/java/org/jboss/pnc/bifrost/endpoint/LogUpload.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.bifrost.source.db.LogEntry;
 import org.jboss.pnc.bifrost.source.db.LogEntryRepository;
 import org.jboss.pnc.bifrost.source.db.converter.ValueConverter;
 import org.jboss.pnc.bifrost.source.db.converter.idConverter;
+import org.jboss.pnc.common.concurrent.Sequence;
 
 import javax.annotation.security.PermitAll;
 import javax.inject.Inject;
@@ -65,6 +66,7 @@ public class LogUpload {
         Log.info("Receiving logfile");
 
         FinalLog finalLog = new FinalLog();
+        finalLog.id = Sequence.nextId();
         finalLog.logEntry = getLogEntry(headers);
         finalLog.eventTimestamp = logUpload.getEndTime();
         finalLog.loggerName = logUpload.getLoggerName();

--- a/src/main/java/org/jboss/pnc/bifrost/source/db/FinalLog.java
+++ b/src/main/java/org/jboss/pnc/bifrost/source/db/FinalLog.java
@@ -17,12 +17,13 @@
  */
 package org.jboss.pnc.bifrost.source.db;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.panache.common.Sort;
 
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import java.io.IOException;
@@ -36,7 +37,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Entity
-public class FinalLog extends PanacheEntity {
+public class FinalLog extends PanacheEntityBase {
+
+    @Id
+    public long id;
 
     @ManyToOne(optional = false)
     public LogEntry logEntry;

--- a/src/test/java/org/jboss/pnc/bifrost/endpoint/FinalLogTest.java
+++ b/src/test/java/org/jboss/pnc/bifrost/endpoint/FinalLogTest.java
@@ -86,6 +86,7 @@ public class FinalLogTest {
 
     private static FinalLog createFinalLog(String text, LogEntry logEntry, String loggerName, String tag) {
         FinalLog finalLog = new FinalLog();
+        finalLog.id = Sequence.nextId();
         finalLog.logContent = BlobProxy.generateProxy(text.getBytes(StandardCharsets.UTF_8));
         finalLog.logEntry = logEntry;
         finalLog.eventTimestamp = OffsetDateTime.now();


### PR DESCRIPTION
This change is done to be consistent with the id generation strategy in Bifrost and is already used for LogEntry and LogLine.