### PR TITLE
Set socket communication error to 'warn'

### DIFF
--- a/src/main/java/org/jboss/pnc/bifrost/endpoint/websocket/Socket.java
+++ b/src/main/java/org/jboss/pnc/bifrost/endpoint/websocket/Socket.java
@@ -96,7 +96,7 @@ public class Socket {
         if (CONNECTION_CLOSED_BY_USER.equals(error.getMessage())) {
             logger.warn("Socket closed by user.", error);
         } else {
-            logger.error("Socket communication error.", error);
+            logger.warn("Socket communication error.", error);
         }
         unsubscribeSession(session.getId());
     }


### PR DESCRIPTION
There isn't much we can do about this and the 'error' log level pollutes our error log reports. Let's set it to warn instead.