### PR TITLE
[maven-pr] allow contents reading

### DIFF
--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -8,7 +8,8 @@
 
 name: Java CI with Maven
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
We normally allow context reading for `maven-pr` job, see e.g.:
- https://github.com/project-ncl/reqour/blob/main/.github/workflows/maven-pr.yml#L12
- https://github.com/project-ncl/pnc-api/blob/master/.github/workflows/maven-pr.yml#L12

We just forgot to add this permission in this repo.